### PR TITLE
クイズの出力

### DIFF
--- a/src/components/createRoom/Create.js
+++ b/src/components/createRoom/Create.js
@@ -45,7 +45,7 @@ function Create() {
   // const [question10, setQuestion10] = useState("");
   // const [answer10, setAnswer10] = useState("");
 
-  const createRoom = (e) => {
+  async function createRoom(e) {
     e.preventDefault();
     let id = uuidv4();
     // onAuthStateChanged(user, (user) => {
@@ -53,7 +53,8 @@ function Create() {
     // firebaseに追加する → addDoc関数 引数にdbとその中のコレクション名
     // コレクションさえ作れば、以下のプロパティのデータがドキュメントとして追加される
     // setDoc(doc(db, "room-list", roomtitle))にするとidがroomTitleになるが重複した場合 → 上書きされる
-    addDoc(collection(db, "room-list"), {
+    await addDoc(collection(db, "room-list"), {
+      // addCollection
       // addするデータ のプロパティを決める → ここをログイン中のuserごとにしたい
       roomId: id,
       title: roomTitle,
@@ -64,30 +65,33 @@ function Create() {
       createdAt: serverTimestamp(),
       members: [user.displayName],
       // クイズはクイズで分けたほうがいいかもしれん
-      quiz: {
-        q1: {
+      // マップ型の配列に変更
+      quiz: [
+        {
           question: question1,
           answer: answer1,
         },
-        q2: {
+        {
           question: question2,
           answer: answer2,
         },
-        q3: {
+        {
           question: question3,
           answer: answer3,
         },
-        q4: {
+
+        {
           question: question4,
           answer: answer4,
         },
-        q5: {
+        {
           question: question5,
           answer: answer5,
         },
-      },
+      ],
     });
     // all-room-list作成してidをタイトルにする
+    // これにすると同じ名前のルームは最後に作成されたルームに更新される → 実際はルーム自体存在するけどアクセスできない
     setDoc(doc(db, "all-room-list", roomTitle), {
       roomId: id,
       title: roomTitle,
@@ -106,7 +110,7 @@ function Create() {
     setAnswer4("");
     setQuestion5("");
     setAnswer5("");
-  };
+  }
 
   return (
     <div className="create">

--- a/src/components/serchRooms/Quiz.js
+++ b/src/components/serchRooms/Quiz.js
@@ -8,10 +8,12 @@ import {
   query,
   onSnapshot,
   getDoc,
+  getDocs,
 } from "firebase/firestore";
 import db from "../../firebase";
 import { useState } from "react";
 import "./quiz.css";
+import { async } from "@firebase/util";
 function Quiz() {
   // ルームの選択 → room/room.idが指定でidごとのルームにルーティング
   // useParamsでurl内のidを取得
@@ -31,9 +33,24 @@ function Quiz() {
     onSnapshot(q, (querySnapshots) => {
       setRooms(querySnapshots.docs.map((doc) => doc.data()));
       setDocId(querySnapshots.docs.map((doc) => doc.id));
-      setRoom(rooms.find((x) => x.title === params.id));
     });
   }, []);
+
+  function getRoom() {
+    const roomList = collection(db, "room-list");
+    const q = query(roomList, orderBy("createdAt", "desc"));
+
+    getDocs(q).then((querySnapshot) => {
+      setRoom(rooms.find((x) => x.title === params.id));
+    });
+    // onSnapshot(q, (querySnapshots) => {
+    //   setRoom(rooms.find((x) => x.title === params.id));
+    // });
+    return room;
+  }
+
+  const selectRoom = getRoom();
+
   // const room = doc(db, "room-list", "4D8Ab5Jd0sUSlrZ3IeUc");
   // const roomSnap = getDoc(room);
 
@@ -44,7 +61,12 @@ function Quiz() {
     <div>
       {/* roomのタイトル → data/chatRooms指定*/}
       <div className="quizList">
-        <h2 className="quiz_header">{rooms.title}</h2>
+        {/* これ挟まないとエラー */}
+        {selectRoom ? (
+          <h2 className="quiz_header">{selectRoom.title}</h2>
+        ) : (
+          console.log("no select")
+        )}
         {/* {room.map((r) =>
           // 似たような感じで出力したファイルあるはず
           console.log(r.quiz)
@@ -54,7 +76,13 @@ function Quiz() {
         {/* とれてますね */}
         {/* 一旦roomがとれたら、room.~~アクセスできる */}
         {/* マップが使えない */}
-        {console.log("room : ", room)}
+        {/* あとからアクセスで */}
+        {console.log("指定したルーム", selectRoom)}
+        {/* はてなをつけると出力できます */}
+        {selectRoom?.quiz?.map((value) => {
+          // 構造的な問題でした
+          return <p>{value.question}</p>;
+        })}
 
         <Link to="/search-rooms">⬅️ Back to all rooms</Link>
       </div>

--- a/src/components/serchRooms/RoomList.js
+++ b/src/components/serchRooms/RoomList.js
@@ -20,7 +20,7 @@ function RoomList() {
     const roomsData = collection(db, "room-list");
     const qq = query(roomsData);
     onSnapshot(qq, (querySnapshots) => {
-      setDocId(querySnapshots.docs.map((doc) => doc.id));
+      setDocId(querySnapshots.docs.map((doc) => doc.data()));
     });
   }, []);
   return (


### PR DESCRIPTION
・データベースの構造を変えました → createファイルのとこquizをマップ型の配列に変更 → 入れ子の構造を改善しました ・Quiz.jsで選択されたルームにつなげてドキュメントデータの取得に成功
→ return内で使用するときは?をつけるとエラーを吐かずに出力してくれる
→ データベースの構造を変えたことで、map関数がうまく働くようになる → 配列でないとできない

この先dbの構造を変えるかも → もしくは同じルーム名の作成ができないようにしたい
現状、同じルームの作成をするとルーム自体は作成されるが、all-room-listが更新されるため、更新前のルームにアクセスできなくなる → 同じルーム名の作成はできないように工夫したい  → addDocをsetDocにしてidを自動ではなくルーム名にすればいい？