### PR TITLE
めちゃくちゃコード汚いけど、各ルームに遷移 → チャット機能実装

### DIFF
--- a/src/components/AuthenticatedApp/index.jsx
+++ b/src/components/AuthenticatedApp/index.jsx
@@ -8,6 +8,7 @@ import SerchRooms from '../../pages/SearchRooms';
 import RoomQuiz from '../../pages/RoomQuiz';
 import CreateRoom from '../../pages/CreateRoom';
 import ScorePage from '../../pages/ScorePage';
+import ChatRoomPage from '../../pages/ChatRoomPage';
 
 function AuthenticatedApp() {
     return (
@@ -34,7 +35,9 @@ function AuthenticatedApp() {
                 <Route path='/create-room' element={<CreateRoom />} />
                 
                 {/* 採点後画面 */}
-                <Route path='/search-rooms/:id/quiz/score' element={ <ScorePage/>} />
+                <Route path='/search-rooms/:id/quiz/score' element={<ScorePage />} />
+                {/* チャットルーム画面 */}
+                <Route path='/room/:id/chat-room' element={ <ChatRoomPage/>} />
 
             </Routes>
         </BrowserRouter>

--- a/src/components/ChatRoom/Chat.js
+++ b/src/components/ChatRoom/Chat.js
@@ -1,0 +1,72 @@
+import { Link, useParams } from "react-router-dom";
+import { chatRooms } from "../../data/chatRooms";
+import { MessageInput } from "../MessageInput";
+import { MessageList } from "../MessageList";
+import "./chat.css";
+import React, { useEffect } from "react";
+import {
+  collection,
+  orderBy,
+  query,
+  onSnapshot,
+  getDocs,
+  doc,
+} from "firebase/firestore";
+import db from "../../firebase";
+import { useState } from "react";
+import { useAuth } from "../../hooks/useAuth";
+import ChatMessageList from "../MessageList/ChatMessageList";
+import ChatMessageInput from "../MessageInput/ChatMessageInput";
+
+function Chat() {
+  // ルームの選択 → room/room.idが指定でidごとのルームにルーティング
+  // useParamsでurl内のidを取得
+  const params = useParams();
+
+  // 編集
+  const [rooms, setRooms] = useState([]);
+  // const [docId, setDocId] = useState([]);
+  const [room, setRoom] = useState([]);
+  const { user } = useAuth();
+  const userInfo = doc(db, "user", `${user.uid}`);
+
+  useEffect(() => {
+    // ここで直接ドキュメントidを指定 → urlはテキストに戻してわかりやすk
+    const roomList = collection(db, "room-list");
+    const q = query(roomList, orderBy("createdAt", "desc"));
+    onSnapshot(q, (querySnapshots) => {
+      setRooms(querySnapshots.docs.map((doc) => doc.data())); // roomsにはすべてのルームのデータ
+    });
+  }, []);
+
+  function getRoom() {
+    const roomList = collection(db, "room-list");
+    const q = query(roomList, orderBy("createdAt", "desc"));
+
+    getDocs(q).then((querySnapshot) => {
+      // ここでurl内のid(ルーム名)とroom-listにあるルーム一覧データのtitleが同じものを取り出す → roomにセット
+      setRoom(rooms.find((x) => x.title === params.id));
+    });
+    return room;
+  }
+  // 上で特定したroomのデータをselectRoomに入れる
+  const selectRoom = getRoom();
+
+  return (
+    <>
+      {console.log("url内のid : ", params.id)}
+      <div className="chat">
+        <h2 className="chat-header">{selectRoom?.title}</h2>
+        <Link to="/rooms">⬅️ Back to all rooms</Link>
+
+        <div className="messages-container">
+          {/* そもそもちゃんとpropsを渡せてない */}
+          <ChatMessageList roomId={params.id} />
+          <ChatMessageInput roomId={params.id} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Chat;

--- a/src/components/ChatRoom/chat.css
+++ b/src/components/ChatRoom/chat.css
@@ -1,0 +1,37 @@
+.chat {
+    flex: 0.7;
+    border-right: 1px solid var(--twitter-background);
+    border-left: 1px solid var(--twitter-background);
+    /* スクロール → chromeのみに適用される */
+    overflow-y: scroll;
+    /* スクロールバーを消す */
+    min-width: 300px;
+    /* flex: none; */
+}
+
+.messages-container {
+    width: 100%;
+    padding: 16px;
+    flex-grow: 1;
+    border: 1px solid var(--color-gray);
+    border-radius: var(--border-radius);
+    /* overflow: hidden; */
+    flex-direction: row;
+    flex: none;
+}
+
+.chat::-webkit-scrollbar {
+    display: none;
+}
+
+/* headerのcss */
+.chat-header {
+    /* 固定 → stickyで固定*/
+    position: sticky;
+    top: 0;
+    background-color: white;
+    /* headerは一番上に来てほしいので100を当てる */
+    z-index: 100;
+    border: 1px solid var(--twitter-background);
+    padding: 5px, 20px;
+}

--- a/src/components/Landing/index.jsx
+++ b/src/components/Landing/index.jsx
@@ -1,8 +1,28 @@
 import { Link } from 'react-router-dom';
 import { chatRooms } from '../../data/chatRooms';
 import './styles.css';
+import { useState,useEffect } from 'react';
+import { collection, query, onSnapshot } from 'firebase/firestore';
+import db from '../../firebase';
 
 function Landing() {
+    const [rooms, setRooms] = useState([]);
+    const [docId, setDocId] = useState("");
+    
+     // マウント時に一回だけ読み込み → room-listの中身全部持ってこれる
+  useEffect(() => {
+    const allroomsData = collection(db, "all-room-list");
+    const q = query(allroomsData);
+    onSnapshot(q, (querySnapshots) => {
+      setRooms(querySnapshots.docs.map((doc) => doc.data()));
+    });
+    // ドキュメントidを取得するため
+    const roomsData = collection(db, "room-list");
+    const qq = query(roomsData);
+    onSnapshot(qq, (querySnapshots) => {
+      setDocId(querySnapshots.docs.map((doc) => doc.data()));
+    });
+  }, []);
     return (
         <>
             <div className='landing'>
@@ -16,7 +36,13 @@ function Landing() {
                     </li>
                 ))}
                     
-                {/* firestoreに登録されたroomを取得したい */}
+                    {/* firestoreに登録されたroomを取得したい */}
+                    {rooms.map((room) => (
+                        <li key={room.roomId}>
+                            <Link to={`/room/${room.title}/chat-room`}>{ room.title}</Link>
+                            
+                        </li>
+                    ))}
             </ul>
 
             </div>

--- a/src/components/MessageInput/ChatMessageInput.js
+++ b/src/components/MessageInput/ChatMessageInput.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { useAuth } from "../../hooks/useAuth";
+import { sendMessage } from "../../firebase";
+
+function ChatMessageInput({ roomId }) {
+  // ログインユーザー情報
+  const { user } = useAuth();
+  const [value, setValue] = React.useState("");
+  // これは入力欄に入力された文字を変数に格納する処理かな
+  const handleChange = (event) => {
+    setValue(event.target.value);
+  };
+  // 送信ボタンクリックで発火する送信処理の関数かな
+  const handleSubmit = (event) => {
+    // これでリロードしないようにしてる
+    event.preventDefault();
+    // firebaseのsendMessage関数を呼び出して、dbに値をセット
+    // 引数にroomIdとuserとvalue(入力テキスト)をprops
+    sendMessage(roomId, user, value);
+    // 送信後は入力欄を空にする
+    setValue("");
+  };
+
+  return (
+    //   {/* // buttonで実行 → handlSubmit */}
+    <div>
+      <form onSubmit={handleSubmit} className="message-input-container">
+        <input
+          type="text"
+          placeholder="Enter a message"
+          value={value}
+          // 入力されると変数にセット
+          onChange={handleChange}
+          className="message-input"
+          // 空送信できないように
+          required
+          minLength={1}
+        />
+        <button type="submit" disabled={value < 1} className="send-message">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default ChatMessageInput;

--- a/src/components/MessageList/ChatMessageList.js
+++ b/src/components/MessageList/ChatMessageList.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { useAuth } from "../../hooks/useAuth";
+// import { useMessages } from "../../hooks/useMessages";
+import { useEffect, useState } from "react";
+import db, { getMessages } from "../../firebase";
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+  getDocs,
+} from "firebase/firestore";
+import { useMessages } from "../../hooks/useMessages";
+import { useParams } from "react-router-dom";
+
+// roomIdが取得できない問題 propsをやめるかあ
+function ChatMessageList({ roomId }) {
+  const params = useParams();
+
+  const containerRef = React.useRef(null);
+  // ログインユーザー情報取得
+  const { user } = useAuth();
+  React.useLayoutEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  });
+  //   const [selectRoomId, setSelectRoomId] = useState("");
+  //   useEffect(() => {
+  //     setSelectRoomId(roomId);
+  //   }, [roomId]);
+  //   roomIdを取得できたタイミングで発火 そもそもundefindで送られてる → if文使えばしゅつりょくはできるけどエラー
+  const messages = useMessages(params.id);
+
+  //   const [messages, setMessages] = useState([]);
+  //   useEffect(() => {
+  //     // ここにmessagesのコード → propsで渡されるroomIdの取得の問題
+  //     if (roomId) {
+  //       const chatList = collection(db, "chat-rooms", roomId, "messages");
+  //       const q = query(chatList);
+  //       onSnapshot(q, (querySnapshots) => {
+  //         setMessages(querySnapshots.docs.map((doc) => doc.data()));
+  //       });
+  //       console.log(messages);
+  //     }
+  //   }, [roomId]);
+
+  //   const messages = useMessages(roomId);
+  // メッセージは送れる indexOfのエラー
+  // useEffectのところをコメントアウトして、出力できてから外すと何故か出力できる
+  // propsで引き渡すのを辞める
+
+  return (
+    <div className="message-list-container" ref={containerRef}>
+      <ul className="message-list"></ul>
+      {/* <div>{roomId}</div>
+      {messages.map((message) => (
+        <li key={message.messageId}>{message.text}</li>
+      ))} */}
+      {messages.map((x) => (
+        <Message key={x.id} message={x} isOwnMessage={x.uid === user.uid} />
+      ))}
+    </div>
+  );
+}
+// あんまし何やってるかわからん
+function Message({ message, isOwnMessage }) {
+  const { displayName, text } = message;
+
+  return (
+    <li className={["message", isOwnMessage && "own-message"].join(" ")}>
+      <h4 className="sender">{isOwnMessage ? "You" : displayName}</h4>
+      <div>{text}</div>
+    </li>
+  );
+}
+
+export default ChatMessageList;

--- a/src/components/MessageList/index.jsx
+++ b/src/components/MessageList/index.jsx
@@ -21,6 +21,7 @@ function MessageList({ roomId }) {
         <div className="message-list-container" ref={containerRef}>
             <ul className="message-list">
                 {/* messagesは多分ルーム内の全メッセージデータ → useMessagesで取得 */}
+                {console.log(messages)}
                 {messages.map((x) => (
                     // メッセージcomponentにプロパティをpropsで渡す
                     // この下にMessageの関数コンポーネントあります

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -80,6 +80,7 @@ async function sendMessage(roomId, user, text) {
       displayName: user.displayName,
       text: text.trim(),
       timestamp: serverTimestamp(),
+      messageId: uuidv4(),
     });
   } catch (error) {
     console.error(error);

--- a/src/pages/ChatRoomPage.js
+++ b/src/pages/ChatRoomPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Landing } from "../components/Landing";
+import Sidebar from "../components/sidebar/Sidebar";
+import Chat from "../components/ChatRoom/Chat";
+function ChatRoomPage() {
+  return (
+    <div className="app">
+      <Sidebar />
+      <Landing />
+      <Chat />
+    </div>
+  );
+}
+
+export default ChatRoomPage;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,16 +10,19 @@ import { useAuth } from "../hooks/useAuth";
 export function Home() {
   const { user } = useAuth();
   // userドキュメント追加
-  // ログインと同時に
+  // ログインと同時に初期化される → if分岐させるか、
   useEffect(() => {
     // setDoc(collection(db, "user", `${user.uid}`))みたいにドキュメントIDを指定
-    setDoc(doc(db, "user", `${user.uid}`), {
-      name: user.displayName,
-      uid: user.uid,
-      icon: user.photoURL,
-      email: user.email,
-      myRoomList: [],
-    });
+    user
+      ? console.log("登録済み")
+      : setDoc(doc(db, "user", `${user.uid}`), {
+          name: user.displayName,
+          uid: user.uid,
+          icon: user.photoURL,
+          email: user.email,
+          myRoomList: [],
+        });
+    // console.log("登録しました");
   }, []);
   return (
     // pagesフォルダにあるpageファイルはなるべくPageをファイル名につけたい


### PR DESCRIPTION
→ propsの受け渡し → selectRoom?.titleだとundefindが引き渡されて、機能しない だから、直接roomIdのところを"テストルーム"にするとテストルームだけのアクセスなら出来るようになる

propsでの受け渡しではなくurl内のidを直接useMessageにセット
params.idでアクセスできる

リファクタリングしてください

todo
・リファクタリング
・自分の登録済みルームのみを出力